### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/pwn2own0456/8fc38019-4ecd-424e-8d05-034d754aa5e9/c4f4c935-e919-4291-81d8-dd0f3118881a/_apis/work/boardbadge/5555ca05-0590-495a-9f5c-de69509cdf5c)](https://dev.azure.com/pwn2own0456/8fc38019-4ecd-424e-8d05-034d754aa5e9/_boards/board/t/c4f4c935-e919-4291-81d8-dd0f3118881a/Microsoft.RequirementCategory)
 # col_public_repo
 col_public_repo
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#4](https://dev.azure.com/pwn2own0456/8fc38019-4ecd-424e-8d05-034d754aa5e9/_workitems/edit/4). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.